### PR TITLE
Support Databox API version 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Change Log
+Following guidelines of http://keepachangelog.com/
+
+## [Unreleased]
+- update to support pushapi version 3
+
+## [1.3] - Jan 25, 2016
+
+- Use `GET /lastpushes`
+- Update for test suite
+- Update for UA version
+- Update to example (read `DATABOX_PUSH_TOKEN` from `ENV`)
+- Test for `rawGet`
+
+## [1.2] - Jan 5, 2016
+- updated package on https://packagist.org
+- support for https://codeclimate.com
+- support for https://coveralls.io
+- updated `guzzle` to latest version
+- removed `styleci`
+- removed support for php `5.4`
+- added badges for `Scrutinizer`, `versioneye`, `License`
+
+## [1.1.1] - Jul 23, 2015
+- Bugfix for using attributes in `insertAll`
+
+## [1.1] - Jul 23, 2015
+- support for attributes
+- contributors guide
+- code style guidelines & fixers
+
+## [1.0] - Jul 2, 2015
+- Adding couple of flags
+
+[Unreleased]: https://github.com/databox/api/compare/1.3...master
+[1.3]: https://github.com/databox/api/compare/1.2...1.3
+[1.2]: https://github.com/databox/api/compare/1.1.1...1.2
+[1.1.1]: https://github.com/databox/api/compare/1.1...1.1.1
+[1.1]: https://github.com/databox/api/compare/1.0...1.1
+[1.0]: https://github.com/databox/databox-php/tree/1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 Following guidelines of http://keepachangelog.com/
 
 ## [Unreleased]
-- update to support pushapi version 3
+- update to support Databox API version 3
 
 ## [1.3] - Jan 25, 2016
-
 - Use `GET /lastpushes`
 - Update for test suite
 - Update for UA version
@@ -32,9 +31,9 @@ Following guidelines of http://keepachangelog.com/
 ## [1.0] - Jul 2, 2015
 - Adding couple of flags
 
-[Unreleased]: https://github.com/databox/api/compare/1.3...master
-[1.3]: https://github.com/databox/api/compare/1.2...1.3
-[1.2]: https://github.com/databox/api/compare/1.1.1...1.2
-[1.1.1]: https://github.com/databox/api/compare/1.1...1.1.1
-[1.1]: https://github.com/databox/api/compare/1.0...1.1
+[Unreleased]: https://github.com/databox/databox-php/compare/1.3...master
+[1.3]: https://github.com/databox/databox-php/compare/1.2...1.3
+[1.2]: https://github.com/databox/databox-php/compare/1.1.1...1.2
+[1.1.1]: https://github.com/databox/databox-php/compare/1.1...1.1.1
+[1.1]: https://github.com/databox/databox-php/compare/1.0...1.1
 [1.0]: https://github.com/databox/databox-php/tree/1.0

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 [![Dependency Status](https://www.versioneye.com/user/projects/55c28ebb653762001a00289b/badge.svg?style=flat)](https://www.versioneye.com/user/projects/55c28ebb653762001a00289b)
 [![License](http://img.shields.io/:license-mit-blue.svg)](http://databox.mit-license.org)
 
+[![HHVM Status](http://hhvm.h4cc.de/badge/databox/databox.svg?style=flat-square)](http://hhvm.h4cc.de/package/databox/databox)
+[![Latest Stable Version](https://poser.pugx.org/databox/databox/v/stable)](https://packagist.org/packages/databox/databox)
+
 
 The PHP SDK for interacting with the [Databox](http://databox.com) Push API.
 
@@ -66,6 +69,12 @@ $ok = $c->push('sales', 203, null, [
 print_r(
     $c->lastPush(3)
 );
+
+// Or push with units
+$c->insertAll([
+    ['transaction', 12134, null, null, 'USD'],
+    ['transaction', 3245, null, null, 'EUR']
+]);
 
 ```
 

--- a/example.php
+++ b/example.php
@@ -10,15 +10,18 @@ if (!$token) {
     $token = 'adxg1kq5a4g04k0wk0s4wkssow8osw84';
 }
 
+$sha = [];
 $c = new Client($token);
 
 $ok = $c->push('sales', rand(100, 10000));
 if ($ok) {
+    $sha[] = $ok;
     echo "Inserted with value,...\n";
 }
 
 $ok = $c->push('sales', rand(100, 10000), (new \DateTime('now'))->format('Y-m-d'));
 if ($ok) {
+    $sha[] = $ok;
     echo "Inserted with date,...\n";
 }
 
@@ -28,12 +31,22 @@ $ok = $c->push('referal', rand(100, 10000), (new \DateTime('yesterday'))->format
     'site'    => 'https://databox.com'
 ]);
 if ($ok) {
+    $sha[] = $ok;
     echo "Inserted with attributes,...\n";
 }
 
-print_r(
-    $c->lastPush(3)
-);
+echo "\nGet last 3 pushes\n",
+    json_encode($c->lastPush(3)),
+    "\n";
+
+// get pushes
+echo "\nGet last push with ::getPush\n",
+    json_encode($c->getPush(end($sha))),
+    "\n";
+
+echo "\nGet last 3 pushes with ::getPush\n",
+    json_encode($c->getPush($sha)),
+    "\n";
 
 // Insert with unit
 $c->insertAll([
@@ -42,17 +55,14 @@ $c->insertAll([
     ['transaction', rand(100, 10000), null, null, 'GBP']
 ]);
 
-print_r(
-    $c->lastPush()
-);
+echo "\nGet last push with ::lastPush\n",
+    json_encode($c->lastPush()),
+    "\n";
 
-// get list of metrics
-print_r(
-    $c->metrics()
-);
+echo "\nGet list of metrics\n",
+    json_encode($c->metrics()),
+    "\n";
 
-// purge pushed data
-print_r(
-    $c->purge()
-);
-
+echo "\nPurge pushed data\n",
+    json_encode($c->purge()),
+    "\n";

--- a/example.php
+++ b/example.php
@@ -12,16 +12,47 @@ if (!$token) {
 
 $c = new Client($token);
 
-$ok = $c->push('sales', 203);
+$ok = $c->push('sales', rand(100, 10000));
 if ($ok) {
-    echo 'Inserted,...';
+    echo "Inserted with value,...\n";
 }
 
+$ok = $c->push('sales', rand(100, 10000), (new \DateTime('now'))->format('Y-m-d'));
+if ($ok) {
+    echo "Inserted with date,...\n";
+}
+
+$ok = $c->push('referal', rand(100, 10000), (new \DateTime('yesterday'))->format('Y-m-d'), [
+    'country' => 'Slovenia',
+    'city'    => 'Ptuj',
+    'site'    => 'https://databox.com'
+]);
+if ($ok) {
+    echo "Inserted with attributes,...\n";
+}
+
+print_r(
+    $c->lastPush(3)
+);
+
+// Insert with unit
 $c->insertAll([
-    ['sales', 203],
-    ['sales', 103, '2015-01-01 17:00:00']
+    ['transaction', rand(100, 10000), null, null, 'USD'],
+    ['transaction', rand(100, 10000), null, null, 'EUR'],
+    ['transaction', rand(100, 10000), null, null, 'GBP']
 ]);
 
 print_r(
-    $c->lastPush(2)
+    $c->lastPush()
 );
+
+// get list of metrics
+print_r(
+    $c->metrics()
+);
+
+// purge pushed data
+print_r(
+    $c->purge()
+);
+

--- a/src/Databox/Client.php
+++ b/src/Databox/Client.php
@@ -82,6 +82,15 @@ class Client extends GuzzleClient
         return $this->rawGet(sprintf('/lastpushes?limit=%d', $n));
     }
 
+    public function getPush($sha)
+    {
+        if (is_array($sha) && !empty($sha)) {
+            return $this->rawGet('/lastpushes?id=' . implode(',', $sha));
+        } else {
+            return $this->rawGet("/lastpushes/{$sha}");
+        }
+    }
+
     public function metrics()
     {
         return $this->rawGet('/metrickeys');

--- a/src/Databox/Client.php
+++ b/src/Databox/Client.php
@@ -6,20 +6,24 @@ use GuzzleHttp\Client as GuzzleClient;
 
 class Client extends GuzzleClient
 {
+    const API_VERSION  = '2.0';
+    const API_ENDPOINT = 'https://push.databox.com';
+
     public function __construct($pushToken = null)
     {
+        $majorVer = explode('.', self::API_VERSION)[0];
         parent::__construct([
-            'base_uri' => 'https://push2new.databox.com',
-            'headers' => [
-                'User-Agent' => 'databox-php/1.3',
+            'base_uri' => self::API_ENDPOINT,
+            'headers'  => [
+                'User-Agent'   => 'databox-php/' . self::API_VERSION,
                 'Content-Type' => 'application/json',
-                'Accept' => 'application/json'
+                'Accept'       => 'application/vnd.databox.v' . $majorVer . '+json'
             ],
             'auth' => [$pushToken, '', 'Basic']
         ]);
     }
 
-    public function rawPush($path = '/', $data = [])
+    public function rawPost($path = '/', $data = [])
     {
         return json_decode($this->post($path, $data)->getBody(), true);
     }
@@ -29,11 +33,19 @@ class Client extends GuzzleClient
         return json_decode($this->get($path)->getBody(), true);
     }
 
-    private function processKPI($key, $value, $date = null, $attributes = null)
+    private function rawDelete($path)
+    {
+        return json_decode($this->delete($path)->getBody(), true);
+    }
+
+    private function processKPI($key, $value, $date = null, $attributes = null, $unit = null)
     {
         $data = [sprintf('$%s', trim($key, '$')) => $value];
         if (!is_null($date)) {
             $data['date'] = $date;
+        }
+        if (!is_null($unit)) {
+            $data['unit'] = $unit;
         }
 
         if (is_array($attributes)) {
@@ -43,30 +55,40 @@ class Client extends GuzzleClient
         return $data;
     }
 
-    public function push($key, $value, $date = null, $attributes = null)
+    public function push($key, $value, $date = null, $attributes = null, $unit = null)
     {
-        $response = $this->rawPush('/', [
-            'json' => ['data' => [$this->processKPI($key, $value, $date, $attributes)]]
+        $response = $this->rawPost('/', [
+            'json' => ['data' => [$this->processKPI($key, $value, $date, $attributes, $unit)]]
         ]);
 
-        return $response['status'] === 'ok';
+        return $response['id'];
     }
 
     public function insertAll($kpis)
     {
-        $response = $this->rawPush('/', [
+        $response = $this->rawPost('/', [
             'json' => ['data' => array_map(function ($i) {
-                $i = $i + [null, null, null, null];
+                $i = $i + [null, null, null, null, null];
 
-                return $this->processKPI($i[0], $i[1], $i[2], $i[3]);
+                return $this->processKPI($i[0], $i[1], $i[2], $i[3], $i[4]);
             }, $kpis)]
         ]);
 
-        return $response['status'] === 'ok';
+        return $response['id'];
     }
 
     public function lastPush($n = 1)
     {
-        return $this->rawGet(sprintf('/lastpushes/%d', $n));
+        return $this->rawGet(sprintf('/lastpushes?limit=%d', $n));
+    }
+
+    public function metrics()
+    {
+        return $this->rawGet('/metrickeys');
+    }
+
+    public function purge()
+    {
+        return $this->rawDelete('/data');
     }
 }

--- a/tests/Databox/Tests/ClientTest.php
+++ b/tests/Databox/Tests/ClientTest.php
@@ -54,7 +54,19 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $json = '[]';
         $response = new Response(200, [], $json);
         $client->method('get')->willReturn($response);
-        $this->assertEquals($json, json_encode([]));
+        $this->assertEquals($json, json_encode($client->lastPush()));
+    }
+
+    public function testRawDelete()
+    {
+        $client = $this->getMockBuilder('Databox\Client')
+            ->setMethods(['delete'])
+            ->getMock();
+
+        $json = '[]';
+        $response = new Response(200, [], $json);
+        $client->method('delete')->willReturn($response);
+        $this->assertEquals($json, json_encode($client->purge()));
     }
 
     public function testLastPush()
@@ -78,6 +90,46 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         ]));
     }
 
+    public function testMetrics()
+    {
+        $respose = json_decode('{"metrics":[{"title":"Val","key":"21805|val"},{"title":"Ping","key":"21805|ping"},{"title":"Sales","key":"21805|sales"},{"title":"Transaction","key":"21805|transaction"}]}', true);
+        $this->client->method('rawGet')->willReturn($respose);
+
+        $metrics = $this->client->metrics();
+        $this->assertArrayHasKey('metrics', $metrics);
+        $this->assertTrue(!empty($metrics['metrics']));
+    }
+
+    public function testGetPushWithId()
+    {
+        $sha     = '147130560011282848ac51b10b6c0c';
+        $respose = json_decode('{"request":{"date":"2016-08-16T13:45:21.640Z","body":{"data":[{"$referal":2677,"date":"2016-08-15","country":"Slovenia","city":"Ptuj","site":"https:\/\/databox.com"}]},"errors":[]},"response":{"date":"2016-08-16T13:45:21.645Z","body":{"id":"147130560011282848ac51b10b6c0c"}},"metrics":["21805|referal|country","21805|referal|city","21805|referal|site"]}', true);
+        $this->client->method('rawGet')->willReturn($respose);
+
+        $push = $this->client->getPush($sha);
+        $this->assertArrayHasKey('request', $push);
+        $this->assertArrayHasKey('response', $push);
+        $this->assertArrayHasKey('metrics', $push);
+        $this->assertEquals($sha, $push['response']['body']['id']);
+    }
+
+    public function testGetPushWithMultipleIds()
+    {
+        $sha = [
+            '147130560011282848ac51b10b6c0c',
+            '147130560098f4d9fc0a87f60256bd',
+            '1471305600b12452f84e232768c117'
+        ];
+        $respose = json_decode('[{"request":{"date":"2016-08-16T13:45:21.493Z","body":{"data":[{"$referal":2677,"date":"2016-08-15","country":"Slovenia","city":"Ptuj","site":"https:\/\/databox.com"}]},"errors":[]},"response":{"date":"2016-08-16T13:45:21.500Z","body":{"id":"147130560011282848ac51b10b6c0c"}},"metrics":["21805|referal|country","21805|referal|city","21805|referal|site"]},{"request":{"date":"2016-08-16T13:45:21.493Z","body":{"data":[{"$sales":2874,"date":"2016-08-16"}]},"errors":[]},"response":{"date":"2016-08-16T13:45:21.500Z","body":{"id":"147130560098f4d9fc0a87f60256bd"}},"metrics":["21805|sales"]},{"request":{"date":"2016-08-16T13:45:21.493Z","body":{"data":[{"$sales":9333}]},"errors":[]},"response":{"date":"2016-08-16T13:45:21.500Z","body":{"id":"1471305600b12452f84e232768c117"}},"metrics":["21805|sales"]}]', true);
+        $this->client->method('rawGet')->willReturn($respose);
+
+        $push = $this->client->getPush($sha);
+        $this->assertEquals(3, count($push));
+        $this->assertEquals($sha[0], $push[0]['response']['body']['id']);
+        $this->assertEquals($sha[1], $push[1]['response']['body']['id']);
+        $this->assertEquals($sha[2], $push[2]['response']['body']['id']);
+    }
+
     public function testInsertAll()
     {
         $respose = ['id' => '1471305600b2ec099fde352d6c58b3'];
@@ -86,6 +138,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($respose['id'], $this->client->insertAll([
             ['sales', 53.2],
             ['sales', 50.2, '2015-01-01 17:00:00'],
+            ['sales', 50.2, '2015-01-01 17:00:00', null, 'USD']
         ]));
     }
 }


### PR DESCRIPTION
Update SDK to support API version 3

changes:
- [ ] implement `POST /metrickeys`
- [x] update `GET /lastpushes` to support paging
- [x] implement `GET /lastpushes/{id}` to return specific push
- [x] implement `DELETE /data`
- [ ] handle new format & exceptions
