### PR TITLE
Add support for passing options to Guzzle client

### DIFF
--- a/src/Databox/Client.php
+++ b/src/Databox/Client.php
@@ -9,10 +9,10 @@ class Client extends GuzzleClient
     const API_VERSION  = '2.0';
     const API_ENDPOINT = 'https://push.databox.com';
 
-    public function __construct($pushToken = null)
+    public function __construct($pushToken = null, array $options = [])
     {
         $majorVer = explode('.', self::API_VERSION)[0];
-        parent::__construct([
+        $baseOptions = [
             'base_uri' => self::API_ENDPOINT,
             'headers'  => [
                 'User-Agent'   => 'databox-php/' . self::API_VERSION,
@@ -20,7 +20,10 @@ class Client extends GuzzleClient
                 'Accept'       => 'application/vnd.databox.v' . $majorVer . '+json'
             ],
             'auth' => [$pushToken, '', 'Basic']
-        ]);
+        ];
+        $options = array_merge($options, $baseOptions);
+
+        parent::__construct($options);
     }
 
     public function rawPost($path = '/', $data = [])

--- a/tests/Databox/Tests/ClientTest.php
+++ b/tests/Databox/Tests/ClientTest.php
@@ -23,13 +23,20 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $accept    = 'application/vnd.databox.v' . self::API_VERSION . '+json';
         $token     = 'test-token';
         $baseUrl   = 'https://push.databox.com';
+        $options   = [
+            'headers' => ['User-Agent' => 'Do not overwrite this'],
+            'proxy' => [
+                'http'  => 'tcp://localhost:8125',
+            ]
+        ];
 
-        $client = new Client($token);
+        $client = new Client($token, $options);
         $this->assertEquals($mimeType, $client->getConfig('headers')['Content-Type']);
         $this->assertEquals($userAgent, $client->getConfig('headers')['User-Agent']);
         $this->assertEquals($accept, $client->getConfig('headers')['Accept']);
         $this->assertEquals($baseUrl, (string) $client->getConfig('base_uri'));
         $this->assertEquals($token, $client->getConfig('auth')[0]);
+        $this->assertEquals($options['proxy']['http'], $client->getConfig('proxy')['http']);
     }
 
     public function testRawPost()


### PR DESCRIPTION
This is useful for specifying a proxy, without relying on `HTTP_PROXY` and `HTTPS_PROXY`, for example.

The default values set in `Databox\Client:16-22` cannot be changed be implementor